### PR TITLE
Move Ownable and Pausable to separate interfaces

### DIFF
--- a/BaseERC1155.sol
+++ b/BaseERC1155.sol
@@ -2,43 +2,14 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/security/Pausable.sol";
 import "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Burnable.sol";
 import "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Supply.sol";
 
-contract BaseERC1155 is ERC1155, Ownable, Pausable, ERC1155Burnable, ERC1155Supply {
+contract BaseERC1155 is ERC1155, ERC1155Burnable, ERC1155Supply {
     constructor() ERC1155("") {}
-
-    function setURI(string memory newuri) public onlyOwner {
-        _setURI(newuri);
-    }
-
-    function pause() public onlyOwner {
-        _pause();
-    }
-
-    function unpause() public onlyOwner {
-        _unpause();
-    }
-
-    function mint(address account, uint256 id, uint256 amount, bytes memory data)
-        public
-        onlyOwner
-    {
-        _mint(account, id, amount, data);
-    }
-
-    function mintBatch(address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data)
-        public
-        onlyOwner
-    {
-        _mintBatch(to, ids, amounts, data);
-    }
 
     function _beforeTokenTransfer(address operator, address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data)
         internal
-        whenNotPaused
         override(ERC1155, ERC1155Supply)
     {
         super._beforeTokenTransfer(operator, from, to, ids, amounts, data);

--- a/BaseERC721.sol
+++ b/BaseERC721.sol
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
 
-contract BaseERC721 is ERC721, ERC721URIStorage, ERC721Enumerable, ERC721Burnable, Ownable {
+contract BaseERC721 is ERC721, ERC721URIStorage, ERC721Enumerable, ERC721Burnable {
     constructor() ERC721("", "") {}
 
     function _beforeTokenTransfer(address from, address to, uint256 tokenId)

--- a/BaseOwnable.sol
+++ b/BaseOwnable.sol
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract BaseERC20 is ERC20 {
-    constructor() ERC20("", "") {}
+contract BaseOwnable is Ownable {
+    constructor() Ownable() {}
 }

--- a/BasePausable.sol
+++ b/BasePausable.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/security/Pausable.sol";
+
+contract BasePausable is Pausable {
+    constructor() Pausable() {}
+}


### PR DESCRIPTION
Moved out common interfaces to make sure we don't duplicate the same events in logs